### PR TITLE
feat - Now using awk to extract and print testing results

### DIFF
--- a/awk_prog
+++ b/awk_prog
@@ -1,0 +1,31 @@
+# Usage: `awk -v mut=m -v len=n -f pattern file`
+# where m is the name of the mutation
+# where n is the length of the file name
+
+BEGIN {
+    # Set field separator
+    FS=","
+}
+
+# Only print the data in the last line of each file
+ENDFILE {
+    # Print mutation name
+    printf("%-*s", len, mut)
+
+    # Print data extracted from fields
+    # For each field, extract the value
+    for (i = 1; i <= NF; i++) {
+
+        # Split the `i`th field at the ':' to extract the number
+        # Store the result in an array `a`
+        split($i, a, ":")
+
+        # Print the data
+        printf("%-10s", a[2])
+
+        # If the it the last field, print a new line
+        if (i == NF) {
+            printf "\n"
+        }
+    }
+}

--- a/prof-x.sh
+++ b/prof-x.sh
@@ -52,20 +52,21 @@ function run_tests_on_mutants()
 function extract_results()
 {
   echo -e "# Extracting results \n"
-  echo "ID, Tests, Failures, Errors"
+
+  # Set length of the "Mutation:" column
+  # can be possibly computed automatically
+  LENGTH=15
+
+  # Print headers for results
+  printf "%-*s %-10s%-10s%-10s%-10s\n" $LENGTH "Mutation:" "Tests" "Failures" "Errors" "Skipped"
+
+  # Extract results from each mutation
   for m in mutants/mutant_*
   do
     cd $m || exit 1
-    TESTS=$(find target/surefire-reports -name '*.txt' | xargs grep "Tests run" \
-              | cut -d "," -f 1 | cut -d ':' -f 3 | paste -s -d+ - | bc
-    )
-    FAILURES=$(find target/surefire-reports -name '*.txt' | xargs grep "Tests run" \
-              | cut -d "," -f 2 | cut -d ':' -f 2 | paste -s -d+ - | bc
-    )
-    ERRORS=$(find target/surefire-reports -name '*.txt' | xargs grep "Tests run" \
-              | cut -d "," -f 3 | cut -d ':' -f 2 | paste -s -d+ - | bc
-    )
-    echo $m,$TESTS,$FAILURES,$ERRORS
+
+    # Print the result of each mutation
+    awk -v mut=$m -v len=$LENGTH -f awk_prog `find target/surefire-reports -name '*.txt'`
     cd $OLDPWD || exit 1
   done
 }


### PR DESCRIPTION
Replaced the `cut` commands with a single `awk` command to extract and print the
testing results

Added an awk program to be used with the `awk` command

NOTE: The new script has not been fully tested since I do not have the full environment set up, so I couldn't create mutations and run tests. But the awk program was based on the sample output provided in the `README.md` file. So feel free to let me know of any unexpected results.

This is a follow-up after the lecture held at McMaster University on the 16th.